### PR TITLE
Add reasonable warmup timers when first starting the containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       test: service nginx status
       interval: 10s
       timeout: 5s
+      start_period: 300s
       retries: 5
     restart: unless-stopped
 
@@ -62,6 +63,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
     restart: unless-stopped
 
   cache:
@@ -76,6 +78,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
     restart: unless-stopped
 
   celery_worker:
@@ -94,6 +97,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 30s
 
   celery_beat:
     image: wger/server:latest


### PR DESCRIPTION
The first time Wger starts, it does some extra setup things that require a bit more time to finish before the health check calls it quits. This commit adds a reasonable warmup period before it starts to enforce the health checks. 

It addresses #67.