### PR TITLE
Add reasonable warmup timers continued

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       test: wget --no-verbose --tries=1 --spider http://localhost:8000
       interval: 10s
       timeout: 5s
+      start_period: 300s
       retries: 5
     restart: unless-stopped
 
@@ -43,8 +44,8 @@ services:
       test: service nginx status
       interval: 10s
       timeout: 5s
-      start_period: 300s
       retries: 5
+      start_period: 30s
     restart: unless-stopped
 
   db:


### PR DESCRIPTION
As @greenbagels pointed out in https://github.com/wger-project/docker/issues/67#issuecomment-2169131120, I should have also added a `start_period` timer into the `web` section. This PR corrects that. 

Continuation of #83. Addresses #67