### PR TITLE
cleanup naming

### DIFF
--- a/dev-postgres/docker-compose.yml
+++ b/dev-postgres/docker-compose.yml
@@ -1,7 +1,8 @@
+name: wger-dev-postgres
+
 services:
   web:
     image: wger/server:latest
-    container_name: wger_dev_server
     env_file:
       - ../config/prod.env
       - ../config/dev.env
@@ -16,7 +17,6 @@ services:
 
   cache:
     image: redis
-    container_name: wger_dev_cache
     expose:
       - 6379
     healthcheck:
@@ -29,13 +29,12 @@ services:
 
   db:
     image: postgres:15-alpine
-    container_name: wger_dev_db
     environment:
       - POSTGRES_USER=wger
       - POSTGRES_PASSWORD=wger
       - POSTGRES_DB=wger
     volumes:
-      - postgres-dev-data:/var/lib/postgresql/data/
+      - postgres-data:/var/lib/postgresql/data/
     ports:
       - "5432:5432"
     expose:
@@ -49,7 +48,4 @@ services:
     restart: unless-stopped
 
 volumes:
-  postgres-dev-data:
-networks:
-  default:
-    name: wger_dev_network
+  postgres-data:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,7 +1,8 @@
+name: wger-dev
+
 services:
   web:
     image: wger/server:latest
-    container_name: wger_dev_server
     env_file:
       - ../config/prod.env
       - ../config/dev.env
@@ -17,7 +18,6 @@ services:
 
   cache:
     image: redis
-    container_name: wger_dev_cache
     expose:
       - 6379
     healthcheck:
@@ -27,7 +27,3 @@ services:
       retries: 5
       start_period: 30s
     restart: unless-stopped
-
-networks:
-  default:
-    name: wger_dev_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@
 services:
   web:
     image: wger/server:latest
-    container_name: wger_server
     depends_on:
       db:
         condition: service_healthy
@@ -31,7 +30,6 @@ services:
 
   nginx:
     image: nginx:stable
-    container_name: wger_nginx
     depends_on:
       - web
     volumes:
@@ -50,7 +48,6 @@ services:
 
   db:
     image: postgres:15-alpine
-    container_name: wger_db
     environment:
       - POSTGRES_USER=wger
       - POSTGRES_PASSWORD=wger
@@ -69,7 +66,6 @@ services:
 
   cache:
     image: redis
-    container_name: wger_cache
     expose:
       - 6379
     volumes:
@@ -84,7 +80,6 @@ services:
 
   celery_worker:
     image: wger/server:latest
-    container_name: wger_celery_worker
     command: /start-worker
     env_file:
       - ./config/prod.env
@@ -102,7 +97,6 @@ services:
 
   celery_beat:
     image: wger/server:latest
-    container_name: wger_celery_beat
     command: /start-beat
     volumes:
       - celery-beat:/home/wger/beat/


### PR DESCRIPTION
* rely on global project name, which will consistently apply the expected, correct prefix to container, volumes, network, etc names (for prod we leave the default implied name as to not break volume names)
* removes ambiguities where some services had a custom name which didn't match (e.g. 'web' becoming 'server')
* there is no need to set custom container, volume, or network names
* removes naming conflict between network used in the 2 dev stacks