### PR TITLE
Add cache client SSL params to env

### DIFF
--- a/config/prod.env
+++ b/config/prod.env
@@ -98,7 +98,11 @@ DJANGO_CACHE_BACKEND=django_redis.cache.RedisCache
 DJANGO_CACHE_LOCATION=redis://cache:6379/1
 DJANGO_CACHE_TIMEOUT=1296000 # in seconds - 60*60*24*15, 15 Days
 DJANGO_CACHE_CLIENT_CLASS=django_redis.client.DefaultClient
-#DJANGO_CACHE_CLIENT_PASSWORD=abcde... # Only if you changed the redis config
+# DJANGO_CACHE_CLIENT_PASSWORD=abcde... # Only if you changed the redis config
+# DJANGO_CACHE_CLIENT_SSL_KEYFILE=/path/to/ssl_keyfile # Path to an ssl private key.
+# DJANGO_CACHE_CLIENT_SSL_CERTFILE=/path/to/ssl_certfile # Path to an ssl certificate.
+# DJANGO_CACHE_CLIENT_SSL_CERT_REQS=<none | optional | required> # The string value for the verify_mode.
+# DJANGO_CACHE_CLIENT_SSL_CHECK_HOSTNAME=False # If set, match the hostname during the SSL handshake.
 
 #
 # Brute force login attacks


### PR DESCRIPTION
### Description
Follow-up to https://github.com/wger-project/wger/pull/1751

Adds documentation for supplying cache client SSL params in env file.