### PR TITLE
Add docker.io to namepsace the image source

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -43,7 +43,7 @@ services:
 #    ports: !reset []
 
   celery_flower:
-    image: wger/server:latest
+    image: docker.io/wger/server:latest
     command: /start-flower
     env_file:
       - ./config/prod.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
 
 services:
   web:
-    image: wger/server:latest
+    image: docker.io/wger/server:latest
     depends_on:
       db:
         condition: service_healthy
@@ -29,7 +29,7 @@ services:
     restart: unless-stopped
 
   nginx:
-    image: nginx:stable
+    image: docker.io/nginx:stable
     depends_on:
       - web
     volumes:
@@ -47,7 +47,7 @@ services:
     restart: unless-stopped
 
   db:
-    image: postgres:15-alpine
+    image: docker.io/postgres:15-alpine
     environment:
       - POSTGRES_USER=wger
       - POSTGRES_PASSWORD=wger
@@ -66,7 +66,7 @@ services:
     restart: unless-stopped
 
   cache:
-    image: redis
+    image: docker.io/redis
     expose:
       - 6379
     volumes:
@@ -86,7 +86,7 @@ services:
     #mem_limit: 5gb
 
   celery_worker:
-    image: wger/server:latest
+    image: docker.io/wger/server:latest
     command: /start-worker
     env_file:
       - ./config/prod.env
@@ -103,7 +103,7 @@ services:
       start_period: 30s
 
   celery_beat:
-    image: wger/server:latest
+    image: docker.io/wger/server:latest
     command: /start-beat
     volumes:
       - celery-beat:/home/wger/beat/


### PR DESCRIPTION
Without this, on systems where multiple image sources are configured, the user is prompted.  However, only docker.io appears to have the images, so this should be set explicitly to prevent unnecessary user hardship.

# Proposed Changes

-
-

## Related Issue(s)

If applicable, please link to any related issues (`Closes #123`,
`Closes wger-project/other-repo#123`, `See also #123`, etc.)
