### PR TITLE
Suggest updated prod.env settings for trusted domains and reverse proxy

### DIFF
--- a/config/prod.env
+++ b/config/prod.env
@@ -129,7 +129,12 @@ AXES_IPWARE_META_PRECEDENCE_ORDER=HTTP_X_FORWARDED_FOR,REMOTE_ADDR
 DJANGO_DEBUG=False
 WGER_USE_GUNICORN=True
 EXERCISE_CACHE_TTL=18000 # in seconds - 5*60*60, 5 hours
+
+# Site configuration //In production, when using SSL/HTTPS, SITE_URL should be changed to https://yourdomain.com, 
+# Set DJANGO_ALLOWED_HOSTS and DJANGO_CSRF_TRUSTED_ORIGINS to your real domain with HTTPS.
 SITE_URL=http://localhost
+# DJANGO_ALLOWED_HOSTS=yourdomain.com
+# DJANGO_CSRF_TRUSTED_ORIGINS=https://yourdomain.com
 
 #
 # JWT auth


### PR DESCRIPTION
# Description:

When deploying wger behind a reverse proxy or Cloudflare Tunnel, Django requires explicit configuration of allowed hosts and CSRF trusted origins.

This PR proposes updating prod.env with recommended settings to prevent common issues such as CSRF errors, redirect loops, or broken HTTPS detection.
# Proposed Changes
In production, when using SSL/HTTPS, SITE_URL should be changed to https://yourdomain.com, also - Set DJANGO_ALLOWED_HOSTS and DJANGO_CSRF_TRUSTED_ORIGINS to your real domain with HTTPS.
```
# Site configuration 
SITE_URL=http://localhost
SITE_URL=https://yourdomain.com
DJANGO_ALLOWED_HOSTS=yourdomain.com
DJANGO_CSRF_TRUSTED_ORIGINS=https://yourdomain.com
```

# Benefits:

Ensures correct HTTPS handling behind a reverse proxy or Cloudflare Tunnel
Note: Users must replace yourdomain.com with their actual domain.

## Related Issue(s)
See also #134 
