### PR TITLE
Initialize PowerSync storage on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ application server, a reverse proxy, a database, a caching server, and a Celery
 queue, all configured. Data is persisted in volumes, if you want to use folders,
 read the warning in the env file.
 
-**TLDR:** 
+**TLDR:** just do `docker compose up -d`
 
-1. start the containers: `docker compose up -d` 
-1. setup offline mode storage: `docker compose exec web ./manage.py setup-powersync-storage`
+The one-shot `powersync_init` service sets up the database role and schema
+needed for offline mode before PowerSync starts.
 
 For more details, consult the documentation (and the config files):
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,12 +33,24 @@ services:
       retries: 5
     restart: unless-stopped
 
+  powersync_init:
+    image: docker.io/wger/server:latest
+    command: ./manage.py setup-powersync-storage
+    env_file:
+      - ./config/prod.env
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: "no"
+
   powersync:
     depends_on:
       db:
         condition: service_healthy
       web:
         condition: service_healthy
+      powersync_init:
+        condition: service_completed_successfully
 
   nginx:
     image: docker.io/nginx:stable


### PR DESCRIPTION
# Proposed Changes

- Add a one-shot `powersync_init` service that initializes the required PowerSync database role and schema after PostgreSQL becomes healthy.
- Make the `powersync` service wait for successful storage initialization before starting.
- Simplify the README startup instructions to require only `docker compose up -d`.
- Remove the misleading manual initialization steps, where PowerSync could initially fail before the second command was run.

## Related Issue(s)

Closes #162 